### PR TITLE
Fix recipe creation data cloning and cleanup

### DIFF
--- a/Recipe/index.js
+++ b/Recipe/index.js
@@ -22,7 +22,6 @@ module.exports = {
   Location: Location,
   Recipe: Recipe,
   InventoryItem: InventoryItem,
-  DataStore: DataStore,
   ValidationError: ValidationError,
   SEEDS: {
     ME,
@@ -40,4 +39,3 @@ if (require.main === module) {
     console.log('\nInventory');
     console.log(lib.SEEDS.INVENTORY_SEED);
   }
-  

--- a/Recipe/src/lib/utils.js
+++ b/Recipe/src/lib/utils.js
@@ -9,21 +9,24 @@ function toFiniteNumber(value) {
     return Number.isFinite(n) ? n : NaN;
 }
   
-  // copy of plain objects & arrays
+// copy of plain objects & arrays
 function clone(value) {
-    if (Array.isArray(value)) {
-        const out = [];
-        for (let i = 0; i < value.length; i++) out.push(clone(value[i]));
-        return out;
+  if (value instanceof Date) {
+    return new Date(value.getTime());
+  }
+  if (Array.isArray(value)) {
+    const out = [];
+    for (let i = 0; i < value.length; i++) out.push(clone(value[i]));
+    return out;
   }
   if (value && typeof value === 'object') {
-        const copy = {};
-        for (const k in value) {
-            if (Object.prototype.hasOwnProperty.call(value, k)) copy[k] = clone(value[k]);
-        }
-        return copy;
+    const copy = {};
+    for (const k in value) {
+      if (Object.prototype.hasOwnProperty.call(value, k)) copy[k] = clone(value[k]);
     }
-    return value;
+    return copy;
+  }
+  return value;
 }
   
 module.exports = { sanitiseString: sanitiseString, toFiniteNumber: toFiniteNumber, clone: clone };

--- a/Recipe/src/models/Recipe.js
+++ b/Recipe/src/models/Recipe.js
@@ -181,10 +181,6 @@ Recipe.prototype._assignAndValidate = function (patch, isPatch) {
 
   if (errors.length) throw new ValidationError(errors);
 
-  if (!isPatch || next.chef !== undefined) {
-    if (!next.chef) errors.push('chef is required');
-  }
-
   for (const k in next) {
     this[k] = next[k];
   }


### PR DESCRIPTION
## Summary
- Ensure util `clone` handles `Date` objects so created recipes keep their timestamps intact
- Remove redundant chef validation in recipe model and tidy module export list
- Drop undefined `DataStore` export from index

## Testing
- `node -e "require('./Recipe/index.js')"`
- `node - <<'NODE'
const Recipe=require('./Recipe/src/models/Recipe');
const enums=require('./Recipe/src/enums');
const rec=new Recipe({recipeId:'R-test', title:'t', ingredients:[{ingredientName:'a',quantity:1,unit:'g'}], instructions:['step'], mealType:enums.MealType.BREAKFAST, cuisineType:'', prepTime:1, difficulty:enums.Difficulty.EASY, servings:1, chef:'c', createdDate:'2025-07-20'});
console.log(rec.toJSON());
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68c114d088fc8322a94f23e853c02be4