### PR TITLE
Render recipe list with Mongo data and row deletion

### DIFF
--- a/Recipe/src/store.js
+++ b/Recipe/src/store.js
@@ -71,7 +71,12 @@ async function createUser(data) {
 
 async function getAllRecipes() {
   await ensureConnection();
-  return Recipe.find().sort({ createdDate: -1 }).lean();
+  return Recipe.find(
+    {},
+    'recipeId userId title mealType cuisineType prepTime difficulty servings chef createdDate ingredients instructions'
+  )
+    .sort({ createdDate: -1, recipeId: 1 })
+    .lean();
 }
 
 async function getRecipeByRecipeId(recipeId) {

--- a/Recipe/src/views/recipes-list-31477046.html
+++ b/Recipe/src/views/recipes-list-31477046.html
@@ -23,10 +23,7 @@
       <h1 class="text-center mb-1">All Recipes</h1>
       <p class="text-center text-muted mb-4">Discover and manage your culinary collection</p>
       <div class="d-flex justify-content-between align-items-center mb-3">
-        <div>
-          <a class="btn btn-primary" href="/add-recipe-<%= appId %>?userId=<%= userId %>">Add New Recipe</a>
-          <a class="btn btn-danger" href="/delete-recipe-<%= appId %>?userId=<%= userId %>">Delete Recipe</a>
-        </div>
+        <a class="btn btn-primary" href="/add-recipe-<%= appId %>?userId=<%= userId %>">Add New Recipe</a>
         <span class="badge bg-secondary"><%= recipes ? recipes.length : 0 %> recipes</span>
       </div>
 
@@ -85,7 +82,16 @@
                 <td><pre><%= ingLines.join('\n') %></pre></td>
                 <td><pre><%= stepLines.join('\n') %></pre></td>
                 <td>
-                  <button class="btn btn-sm btn-danger" onclick="deleteRecipe('<%= r.recipeId %>')">Delete</button>
+                  <form
+                    method="post"
+                    action="/delete-recipe-<%= appId %>"
+                    class="d-inline"
+                    onsubmit="return confirm('Delete recipe <%= r.recipeId %>?');"
+                  >
+                    <input type="hidden" name="recipeId" value="<%= r.recipeId %>" />
+                    <input type="hidden" name="userId" value="<%= userId %>" />
+                    <button type="submit" class="btn btn-sm btn-danger">Delete</button>
+                  </form>
                 </td>
               </tr>
             <% } %>
@@ -95,24 +101,6 @@
       <% } %>
     </div>
 
-    <script>
-      function deleteRecipe(id) {
-        if (!id) return;
-        if (!confirm('Delete recipe ' + id + '?')) return;
-
-        fetch('/api/recipes/' + encodeURIComponent(id) + '-31477046', {
-          method: 'DELETE'
-        }).then(function (res) {
-          if (res.status === 204) {
-            location.reload();
-          } else {
-            alert('Could not delete (status ' + res.status + ')');
-          }
-        }).catch(function () {
-          alert('Network error while deleting');
-        });
-      }
-    </script>
   </body>
 </html>
 


### PR DESCRIPTION
## Summary
- update the recipe store query to only fetch the fields needed for the list view while keeping results ordered by newest first
- render the recipes list page with inline delete forms that post back to the server so each row can remove its recipe without extra scripts

## Testing
- Not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68d3aac6d3748322af3781c8001d4ef6