### PR TITLE
Add inventory analytics and filtering endpoints

### DIFF
--- a/Recipe/src/store.js
+++ b/Recipe/src/store.js
@@ -118,9 +118,118 @@ async function deleteRecipe(recipeId) {
   return deletedRecipe || null;
 }
 
-async function getAllInventory() {
+function escapeRegExp(value) {
+  return String(value).replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+}
+
+function buildInventoryQuery(filters) {
+  const query = {};
+
+  if (filters && filters.q) {
+    const regex = new RegExp(escapeRegExp(filters.q), 'i');
+    query.$or = [
+      { ingredientName: regex },
+      { inventoryId: regex }
+    ];
+  }
+
+  if (filters && filters.category) {
+    query.category = filters.category;
+  }
+
+  if (filters && filters.location) {
+    query.location = filters.location;
+  }
+
+  if (filters && filters.unit) {
+    query.unit = filters.unit;
+  }
+
+  if (filters && filters.userId) {
+    query.userId = filters.userId;
+  }
+
+  if (filters && filters.expiringBy instanceof Date) {
+    query.expirationDate = Object.assign({}, query.expirationDate, {
+      $lte: filters.expiringBy
+    });
+  }
+
+  if (filters && filters.lowStockBelow !== undefined) {
+    query.quantity = Object.assign({}, query.quantity, {
+      $lte: filters.lowStockBelow
+    });
+  }
+
+  return query;
+}
+
+function buildInventorySort(sortKey) {
+  const fallback = { createdDate: -1, inventoryId: 1 };
+  if (!sortKey || typeof sortKey !== 'string') {
+    return fallback;
+  }
+
+  const trimmed = sortKey.trim();
+  if (!trimmed) {
+    return fallback;
+  }
+
+  const allowed = ['createdDate', 'expirationDate', 'quantity', 'ingredientName'];
+  let direction = 1;
+  let field = trimmed;
+  if (field.charAt(0) === '-') {
+    direction = -1;
+    field = field.substring(1);
+  }
+
+  if (allowed.indexOf(field) === -1) {
+    return fallback;
+  }
+
+  const sort = {};
+  sort[field] = direction;
+  sort.inventoryId = 1;
+  return sort;
+}
+
+function normalisePage(value) {
+  const parsed = parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return 1;
+  }
+  return parsed;
+}
+
+function normaliseLimit(value) {
+  const parsed = parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return 10;
+  }
+  return Math.min(parsed, 50);
+}
+
+async function listInventory(options) {
+  const opts = options || {};
   await ensureConnection();
-  return InventoryItem.find().sort({ createdDate: -1 }).lean();
+
+  const page = normalisePage(opts.page);
+  const limit = normaliseLimit(opts.limit);
+  const query = buildInventoryQuery(opts);
+  const sort = buildInventorySort(opts.sort);
+  const skip = (page - 1) * limit;
+
+  const [items, total] = await Promise.all([
+    InventoryItem.find(query).sort(sort).skip(skip).limit(limit).lean(),
+    InventoryItem.countDocuments(query)
+  ]);
+
+  return { items, total, page, limit };
+}
+
+async function getAllInventory() {
+  const result = await listInventory({ page: 1, limit: 500, sort: '-createdDate' });
+  return result.items;
 }
 
 async function getInventoryItemById(inventoryId) {
@@ -174,19 +283,100 @@ async function setInventoryQuantity(inventoryId, amount) {
   return saved.toObject();
 }
 
+async function findExpiringInventory(options) {
+  const opts = options || {};
+  return listInventory({
+    page: opts.page,
+    limit: opts.limit,
+    expiringBy: opts.by,
+    category: opts.category,
+    location: opts.location,
+    unit: opts.unit,
+    userId: opts.userId,
+    sort: 'expirationDate'
+  });
+}
+
+async function findLowStockInventory(options) {
+  const opts = options || {};
+  await ensureConnection();
+  const query = buildInventoryQuery({
+    category: opts.category,
+    location: opts.location,
+    unit: opts.unit,
+    userId: opts.userId,
+    lowStockBelow: opts.threshold
+  });
+  return InventoryItem.find(query).sort({ quantity: 1, inventoryId: 1 }).lean();
+}
+
+async function calculateInventoryValue(groupBy) {
+  await ensureConnection();
+  const projectStage = {
+    lineValue: {
+      $multiply: [
+        { $ifNull: ['$cost', 0] },
+        { $ifNull: ['$quantity', 0] }
+      ]
+    }
+  };
+
+  if (groupBy) {
+    projectStage.groupField = { $ifNull: ['$' + groupBy, 'Unspecified'] };
+  }
+
+  const pipeline = [
+    { $project: projectStage }
+  ];
+
+  if (groupBy) {
+    pipeline.push({
+      $group: {
+        _id: '$groupField',
+        totalValue: { $sum: '$lineValue' },
+        itemCount: { $sum: 1 }
+      }
+    });
+    pipeline.push({ $sort: { _id: 1 } });
+    const grouped = await InventoryItem.aggregate(pipeline);
+    let total = 0;
+    const breakdown = grouped.map(function (entry) {
+      const value = entry.totalValue || 0;
+      total += value;
+      return {
+        group: entry._id === null ? 'Unspecified' : entry._id,
+        totalValue: value,
+        itemCount: entry.itemCount || 0
+      };
+    });
+    return { totalValue: total, breakdown };
+  }
+
+  pipeline.push({
+    $group: {
+      _id: null,
+      totalValue: { $sum: '$lineValue' }
+    }
+  });
+
+  const totals = await InventoryItem.aggregate(pipeline);
+  const totalValue = totals.length && totals[0].totalValue ? totals[0].totalValue : 0;
+  return { totalValue };
+}
+
 async function getDashboardStats() {
   await ensureConnection();
-  const [recipeCount, inventoryCount, userCount, cuisineInfo, inventoryTotals] = await Promise.all([
+  const [recipeCount, inventoryCount, userCount, cuisineInfo, inventoryValues] = await Promise.all([
     Recipe.countDocuments({}),
     InventoryItem.countDocuments({}),
     User.countDocuments({}),
     Recipe.distinct('cuisineType'),
-    InventoryItem.aggregate([
-      { $group: { _id: null, total: { $sum: '$cost' } } }
-    ])
+    calculateInventoryValue()
   ]);
 
-  const totalValue = inventoryTotals.length && inventoryTotals[0].total ? Number(inventoryTotals[0].total) : 0;
+  const totalValue = inventoryValues && Number.isFinite(inventoryValues.totalValue)
+    ? inventoryValues.totalValue
+    : 0;
 
   return {
     recipeCount,
@@ -210,6 +400,7 @@ module.exports = {
   createRecipe,
   updateRecipe,
   deleteRecipe,
+  listInventory,
   getAllInventory,
   getInventoryItemById,
   createInventoryItem,
@@ -217,5 +408,8 @@ module.exports = {
   deleteInventoryItem,
   adjustInventoryQuantity,
   setInventoryQuantity,
+  findExpiringInventory,
+  findLowStockInventory,
+  calculateInventoryValue,
   getDashboardStats
 };


### PR DESCRIPTION
## Summary
- extend the inventory store with reusable list helpers, low stock lookups, and value aggregation
- update the inventory API routes to support filtering, expiring items, low stock alerts, and value reporting responses

## Testing
- npm test *(fails: "Error: no test specified")*

------
https://chatgpt.com/codex/tasks/task_e_68d3b4680f1483228300c68f98402167