### PR TITLE
Add recipe and inventory edit flows

### DIFF
--- a/Recipe/src/store.js
+++ b/Recipe/src/store.js
@@ -103,7 +103,20 @@ async function createRecipe(data) {
 
 async function updateRecipe(recipeId, patch) {
   await ensureConnection();
-  return Recipe.findOneAndUpdate({ recipeId }, patch, { new: true, runValidators: true }).lean();
+
+  const normalisedId = recipeId ? String(recipeId).trim().toUpperCase() : '';
+  if (!normalisedId) {
+    return null;
+  }
+
+  const update = Object.assign({}, patch || {});
+  delete update.recipeId;
+  if (update.userId) {
+    update.userId = String(update.userId).trim().toUpperCase();
+  }
+  update.updatedAt = new Date();
+
+  return Recipe.findOneAndUpdate({ recipeId: normalisedId }, update, { new: true, runValidators: true }).lean();
 }
 
 async function deleteRecipe(recipeId) {
@@ -246,7 +259,20 @@ async function createInventoryItem(data) {
 
 async function updateInventoryItem(inventoryId, patch) {
   await ensureConnection();
-  return InventoryItem.findOneAndUpdate({ inventoryId }, patch, { new: true, runValidators: true }).lean();
+
+  const normalisedId = inventoryId ? String(inventoryId).trim().toUpperCase() : '';
+  if (!normalisedId) {
+    return null;
+  }
+
+  const update = Object.assign({}, patch || {});
+  delete update.inventoryId;
+  if (update.userId) {
+    update.userId = String(update.userId).trim().toUpperCase();
+  }
+  update.updatedAt = new Date();
+
+  return InventoryItem.findOneAndUpdate({ inventoryId: normalisedId }, update, { new: true, runValidators: true }).lean();
 }
 
 async function deleteInventoryItem(inventoryId) {

--- a/Recipe/src/views/edit-inventory-31477046.html
+++ b/Recipe/src/views/edit-inventory-31477046.html
@@ -1,0 +1,225 @@
+<!doctype html>
+<html lang="en" data-bs-theme="auto">
+  <head>
+    <meta charset="utf-8" />
+    <title>Edit Inventory Item</title>
+    <link rel="stylesheet" href="/bootstrap.min.css" />
+  </head>
+  <body>
+    <div class="container py-4">
+      <div class="mb-3">
+        <a class="btn btn-outline-primary" href="/home-<%= appId %>?userId=<%= userId %>">Return to Home</a>
+      </div>
+
+      <h1 class="text-center mb-1">Edit Inventory Item</h1>
+      <p class="text-center text-muted mb-4">Adjust stock levels, dates and storage details</p>
+
+      <% if (success) { %>
+        <div class="alert alert-success"><%= success %></div>
+      <% } %>
+
+      <% if (error) { %>
+        <div class="alert alert-danger"><%= error %></div>
+      <% } %>
+
+      <% if (!items || !items.length) { %>
+        <div class="alert alert-info">
+          You have no inventory items to edit.
+          <a class="alert-link" href="/add-inventory-<%= appId %>?userId=<%= userId %>">Add an inventory item</a> to get started.
+        </div>
+      <% } else { %>
+        <div class="card mb-4">
+          <div class="card-header">Choose Inventory Item</div>
+          <div class="card-body">
+            <label class="form-label" for="inventorySelection">Select an item to edit</label>
+            <select class="form-select" id="inventorySelection">
+              <% for (let i = 0; i < items.length; i++) { const item = items[i] || {}; %>
+                <option value="<%= item.inventoryId %>" <%= selectedInventoryId === item.inventoryId ? 'selected' : '' %>>
+                  <%= item.inventoryId %>
+                  <% if (item.ingredientName) { %>
+                    - <%= item.ingredientName %>
+                  <% } %>
+                </option>
+              <% } %>
+            </select>
+          </div>
+        </div>
+
+        <form action="/edit-inventory-<%= appId %>" method="POST">
+          <input type="hidden" name="userId" value="<%= defaultUserId %>" />
+
+          <div class="card mb-4">
+            <div class="card-header">Basic Information</div>
+            <div class="card-body">
+              <div class="row">
+                <div class="col-md-4 mb-3">
+                  <label class="form-label">Inventory ID</label>
+                  <input class="form-control" type="text" name="inventoryId" readonly value="<%= values.inventoryId %>" />
+                  <div class="form-text">Format: I-#####</div>
+                </div>
+                <div class="col-md-4 mb-3">
+                  <label class="form-label">User ID</label>
+                  <div class="form-control-plaintext fw-semibold"><%= defaultUserId %></div>
+                </div>
+                <div class="col-md-4 mb-3">
+                  <label class="form-label">Ingredient Name</label>
+                  <input class="form-control" type="text" name="ingredientName" required value="<%= values.ingredientName %>" />
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="card mb-4">
+            <div class="card-header">Item Details</div>
+            <div class="card-body">
+              <div class="row">
+                <div class="col-md-3 mb-3">
+                  <label class="form-label">Quantity</label>
+                  <input class="form-control" type="number" name="quantity" step="0.01" min="0.01" required value="<%= values.quantity %>" />
+                </div>
+                <div class="col-md-3 mb-3">
+                  <label class="form-label">Unit</label>
+                  <select class="form-select" name="unit" required>
+                    <option value="">-- choose --</option>
+                    <% for (let i = 0; i < units.length; i++) { %>
+                      <option value="<%= units[i] %>" <%= values.unit === units[i] ? 'selected' : '' %>><%= units[i] %></option>
+                    <% } %>
+                  </select>
+                </div>
+                <div class="col-md-3 mb-3">
+                  <label class="form-label">Category</label>
+                  <select class="form-select" name="category" required>
+                    <option value="">-- choose --</option>
+                    <% for (let i = 0; i < categories.length; i++) { %>
+                      <option value="<%= categories[i] %>" <%= values.category === categories[i] ? 'selected' : '' %>><%= categories[i] %></option>
+                    <% } %>
+                  </select>
+                </div>
+                <div class="col-md-3 mb-3">
+                  <label class="form-label">Cost</label>
+                  <input class="form-control" type="number" name="cost" step="0.01" min="0.01" required value="<%= values.cost %>" />
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="card mb-4">
+            <div class="card-header">Dates</div>
+            <div class="card-body">
+              <div class="row">
+                <div class="col-md-4 mb-3">
+                  <label class="form-label">Purchase Date</label>
+                  <input class="form-control" type="date" name="purchaseDate" required value="<%= values.purchaseDate %>" />
+                </div>
+                <div class="col-md-4 mb-3">
+                  <label class="form-label">Expiration Date</label>
+                  <input class="form-control" type="date" name="expirationDate" required value="<%= values.expirationDate %>" />
+                </div>
+                <div class="col-md-4 mb-3">
+                  <label class="form-label">Created Date</label>
+                  <input class="form-control" type="date" name="createdDate" value="<%= values.createdDate %>" />
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="card mb-4">
+            <div class="card-header">Location</div>
+            <div class="card-body">
+              <select class="form-select" name="location" required>
+                <option value="">-- choose --</option>
+                <% for (let i = 0; i < locations.length; i++) { %>
+                  <option value="<%= locations[i] %>" <%= values.location === locations[i] ? 'selected' : '' %>><%= locations[i] %></option>
+                <% } %>
+              </select>
+              <div class="form-text">Select one of the approved storage locations.</div>
+            </div>
+          </div>
+
+          <div class="d-flex justify-content-between">
+            <a class="btn btn-outline-secondary" href="/inventory-dashboard-<%= appId %>?userId=<%= userId %>">View Inventory</a>
+            <button class="btn btn-primary" type="submit">Update Item</button>
+          </div>
+        </form>
+      <% } %>
+    </div>
+
+    <script>
+      (function () {
+        const APP_ID = '<%= appId %>';
+        const USER_ID = '<%= userId %>';
+        const select = document.getElementById('inventorySelection');
+        if (select) {
+          select.addEventListener('change', function () {
+            if (!USER_ID) return;
+            let target = '/edit-inventory-' + APP_ID + '?userId=' + encodeURIComponent(USER_ID);
+            if (this.value) {
+              target += '&inventoryId=' + encodeURIComponent(this.value);
+            }
+            window.location.href = target;
+          });
+        }
+
+        const form = document.querySelector('form');
+        if (!form) return;
+        const qtyInput = form.querySelector('input[name="quantity"]');
+        const costInput = form.querySelector('input[name="cost"]');
+        const purchaseDateInput = form.querySelector('input[name="purchaseDate"]');
+        const expirationDateInput = form.querySelector('input[name="expirationDate"]');
+
+        function validateNumbers() {
+          if (qtyInput) qtyInput.setCustomValidity('');
+          if (costInput) costInput.setCustomValidity('');
+          if (expirationDateInput) expirationDateInput.setCustomValidity('');
+
+          if (qtyInput) {
+            const q = Number(qtyInput.value);
+            if (!Number.isFinite(q) || q <= 0) {
+              qtyInput.setCustomValidity('Quantity must be more than zero.');
+            }
+          }
+
+          if (costInput) {
+            const c = Number(costInput.value);
+            if (!Number.isFinite(c) || c <= 0) {
+              costInput.setCustomValidity('Cost must be greater than zero.');
+            }
+          }
+
+          if (purchaseDateInput && expirationDateInput && purchaseDateInput.value && expirationDateInput.value) {
+            const pd = new Date(purchaseDateInput.value);
+            const ed = new Date(expirationDateInput.value);
+            if (!(pd instanceof Date) || isNaN(pd.getTime()) || !(ed instanceof Date) || isNaN(ed.getTime())) {
+              expirationDateInput.setCustomValidity('Dates must be valid.');
+            } else if (ed <= pd) {
+              expirationDateInput.setCustomValidity('Expiration must be after purchase date.');
+            }
+          }
+        }
+
+        if (qtyInput) {
+          qtyInput.addEventListener('input', validateNumbers);
+        }
+        if (costInput) {
+          costInput.addEventListener('input', validateNumbers);
+        }
+        if (purchaseDateInput) {
+          purchaseDateInput.addEventListener('change', validateNumbers);
+        }
+        if (expirationDateInput) {
+          expirationDateInput.addEventListener('change', validateNumbers);
+        }
+
+        form.addEventListener('submit', function (e) {
+          validateNumbers();
+          if (!form.checkValidity()) {
+            e.preventDefault();
+            if (form.reportValidity) {
+              form.reportValidity();
+            }
+          }
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/Recipe/src/views/edit-recipe-31477046.html
+++ b/Recipe/src/views/edit-recipe-31477046.html
@@ -1,0 +1,222 @@
+<!doctype html>
+<html lang="en" data-bs-theme="auto">
+  <head>
+    <meta charset="utf-8" />
+    <title>Edit Recipe</title>
+    <link rel="stylesheet" href="/bootstrap.min.css" />
+  </head>
+  <body>
+    <div class="container py-4">
+      <div class="mb-3">
+        <a class="btn btn-outline-primary" href="/home-<%= appId %>?userId=<%= userId %>">Return to Home</a>
+      </div>
+
+      <h1 class="text-center mb-1">Edit Recipe</h1>
+      <p class="text-center text-muted mb-4">Update recipe information, ingredients and instructions</p>
+
+      <% if (success) { %>
+        <div class="alert alert-success"><%= success %></div>
+      <% } %>
+
+      <% if (error) { %>
+        <div class="alert alert-danger"><%= error %></div>
+      <% } %>
+
+      <% if (!recipes || !recipes.length) { %>
+        <div class="alert alert-info">
+          You have no recipes to edit yet.
+          <a class="alert-link" href="/add-recipe-<%= appId %>?userId=<%= userId %>">Add a new recipe</a> to get started.
+        </div>
+      <% } else { %>
+        <div class="card mb-4">
+          <div class="card-header">Choose Recipe</div>
+          <div class="card-body">
+            <label class="form-label" for="recipeSelection">Select a recipe to edit</label>
+            <select class="form-select" id="recipeSelection">
+              <% for (let i = 0; i < recipes.length; i++) { const recipe = recipes[i] || {}; %>
+                <option value="<%= recipe.recipeId %>" <%= selectedRecipeId === recipe.recipeId ? 'selected' : '' %>>
+                  <%= recipe.recipeId %>
+                  <% if (recipe.title) { %>
+                    - <%= recipe.title %>
+                  <% } %>
+                </option>
+              <% } %>
+            </select>
+          </div>
+        </div>
+
+        <form action="/edit-recipe-<%= appId %>" method="POST">
+          <input type="hidden" name="userId" value="<%= defaultUserId %>" />
+
+          <div class="card mb-4">
+            <div class="card-header">Basic Information</div>
+            <div class="card-body">
+              <div class="row">
+                <div class="col-md-6 mb-3">
+                  <label class="form-label">Recipe Title</label>
+                  <input class="form-control" type="text" name="title" required value="<%= values.title %>" />
+                </div>
+                <div class="col-md-3 mb-3">
+                  <label class="form-label">Recipe ID</label>
+                  <input class="form-control" type="text" name="recipeId" readonly value="<%= values.recipeId %>" />
+                  <div class="form-text">Format: R-#####</div>
+                </div>
+                <div class="col-md-3 mb-3">
+                  <label class="form-label">User ID</label>
+                  <div class="form-control-plaintext fw-semibold"><%= defaultUserId %></div>
+                </div>
+              </div>
+              <div class="row">
+                <div class="col-md-4 mb-3">
+                  <label class="form-label">Chef</label>
+                  <input class="form-control" type="text" name="chef" required value="<%= values.chef %>" />
+                </div>
+                <div class="col-md-4 mb-3">
+                  <label class="form-label">Meal Type</label>
+                  <select class="form-select" name="mealType" required>
+                    <option value="">-- choose --</option>
+                    <% for (let i = 0; i < mealTypes.length; i++) { %>
+                      <option value="<%= mealTypes[i] %>" <%= values.mealType === mealTypes[i] ? 'selected' : '' %>><%= mealTypes[i] %></option>
+                    <% } %>
+                  </select>
+                </div>
+                <div class="col-md-4 mb-3">
+                  <label class="form-label">Cuisine Type</label>
+                  <select class="form-select" name="cuisineType" required>
+                    <option value="">-- choose --</option>
+                    <% for (let i = 0; i < cuisineTypes.length; i++) { %>
+                      <option value="<%= cuisineTypes[i] %>" <%= values.cuisineType === cuisineTypes[i] ? 'selected' : '' %>><%= cuisineTypes[i] %></option>
+                    <% } %>
+                  </select>
+                </div>
+              </div>
+              <div class="row">
+                <div class="col-md-4 mb-3">
+                  <label class="form-label">Difficulty</label>
+                  <select class="form-select" name="difficulty" required>
+                    <option value="">-- choose --</option>
+                    <% for (let i = 0; i < difficulties.length; i++) { %>
+                      <option value="<%= difficulties[i] %>" <%= values.difficulty === difficulties[i] ? 'selected' : '' %>><%= difficulties[i] %></option>
+                    <% } %>
+                  </select>
+                </div>
+                <div class="col-md-4 mb-3">
+                  <label class="form-label">Prep Time (mins)</label>
+                  <input class="form-control" type="number" name="prepTime" min="1" max="480" step="1" required value="<%= values.prepTime %>" />
+                </div>
+                <div class="col-md-4 mb-3">
+                  <label class="form-label">Servings</label>
+                  <input class="form-control" type="number" name="servings" min="1" max="20" step="1" required value="<%= values.servings %>" />
+                </div>
+              </div>
+              <div class="mb-3">
+                <label class="form-label">Created Date</label>
+                <input class="form-control" type="date" name="createdDate" value="<%= values.createdDate %>" />
+              </div>
+            </div>
+          </div>
+
+          <div class="card mb-4">
+            <div class="card-header">Ingredients</div>
+            <div class="card-body">
+              <textarea class="form-control" name="ingredientsText" rows="6" required
+                placeholder="One per line, like:
+Rolled Oats | 60 | g
+Milk | 250 | ml
+Whey Protein | 30 | g"><%= values.ingredientsText %></textarea>
+              <div class="form-text">Each line: <code>name | quantity | unit</code>. Units: pieces, kg, g, liters, ml, cups, tbsp, tsp, dozen.</div>
+            </div>
+          </div>
+
+          <div class="card mb-4">
+            <div class="card-header">Instructions</div>
+            <div class="card-body">
+              <textarea class="form-control" name="instructionsText" rows="6" required placeholder="One step per line"><%= values.instructionsText %></textarea>
+            </div>
+          </div>
+
+          <div class="d-flex justify-content-between">
+            <a class="btn btn-outline-secondary" href="/recipes-list-<%= appId %>?userId=<%= userId %>">View Recipes</a>
+            <button class="btn btn-primary" type="submit">Update Recipe</button>
+          </div>
+        </form>
+      <% } %>
+    </div>
+
+    <script>
+      (function () {
+        const APP_ID = '<%= appId %>';
+        const USER_ID = '<%= userId %>';
+        const select = document.getElementById('recipeSelection');
+        if (select) {
+          select.addEventListener('change', function () {
+            if (!USER_ID) return;
+            let target = '/edit-recipe-' + APP_ID + '?userId=' + encodeURIComponent(USER_ID);
+            if (this.value) {
+              target += '&recipeId=' + encodeURIComponent(this.value);
+            }
+            window.location.href = target;
+          });
+        }
+
+        const form = document.querySelector('form');
+        if (!form) return;
+        const ingredientsInput = form.querySelector('textarea[name="ingredientsText"]');
+
+        function toTrimmed(str) {
+          return typeof str === 'string' ? str.trim() : '';
+        }
+
+        function validateIngredients() {
+          if (!ingredientsInput) return true;
+          ingredientsInput.setCustomValidity('');
+          const text = ingredientsInput.value || '';
+          const lines = text.split(/\r?\n/);
+          let ok = true;
+          let hasContent = false;
+
+          for (let i = 0; i < lines.length; i++) {
+            const line = toTrimmed(lines[i]);
+            if (!line) continue;
+            hasContent = true;
+            const parts = line.split('|');
+            if (parts.length !== 3) { ok = false; break; }
+            const name = toTrimmed(parts[0]);
+            const qtyStr = toTrimmed(parts[1]);
+            const unit = toTrimmed(parts[2]).toLowerCase();
+            const qty = Number(qtyStr);
+            if (!name || !Number.isFinite(qty) || qty <= 0 || !unit) { ok = false; break; }
+          }
+
+          if (!hasContent) {
+            ok = false;
+          }
+
+          if (!ok) {
+            ingredientsInput.setCustomValidity('Ingredients must follow the "name | quantity | unit" format.');
+          }
+
+          return ok;
+        }
+
+        if (ingredientsInput) {
+          ingredientsInput.addEventListener('input', function () {
+            validateIngredients();
+            if (ingredientsInput.reportValidity) {
+              ingredientsInput.reportValidity();
+            }
+          });
+        }
+
+        form.addEventListener('submit', function (e) {
+          if (!validateIngredients()) {
+            e.preventDefault();
+            if (ingredientsInput && ingredientsInput.reportValidity) {
+              ingredientsInput.reportValidity();
+            }
+          }
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/Recipe/src/views/inventory-dashboard-31477046.html
+++ b/Recipe/src/views/inventory-dashboard-31477046.html
@@ -109,6 +109,7 @@
                 <td class="mono"><%= (Number.isFinite(Number(r.cost)) ? Number(r.cost).toFixed(2) : '') %></td>
                 <td class="mono"><%= r.createdDate || '' %></td>
                 <td>
+                  <a class="btn btn-sm btn-secondary mb-1" href="/edit-inventory-<%= appId %>?userId=<%= userId %>&inventoryId=<%= r.inventoryId %>">Edit</a>
                   <button class="btn btn-sm btn-danger" onclick="deleteInventory('<%= r.inventoryId %>')">Delete</button>
                 </td>
               </tr>

--- a/Recipe/src/views/recipes-list-31477046.html
+++ b/Recipe/src/views/recipes-list-31477046.html
@@ -82,6 +82,7 @@
                 <td><pre><%= ingLines.join('\n') %></pre></td>
                 <td><pre><%= stepLines.join('\n') %></pre></td>
                 <td>
+                  <a class="btn btn-sm btn-secondary mb-1" href="/edit-recipe-<%= appId %>?userId=<%= userId %>&recipeId=<%= r.recipeId %>">Edit</a>
                   <form
                     method="post"
                     action="/delete-recipe-<%= appId %>"


### PR DESCRIPTION
## Summary
- add dedicated edit pages for recipes and inventory with pre-filled forms, selection controls, and client-side validation
- extend the server to load and update recipes and inventory items while reusing validation logic and surfacing success feedback
- normalise update operations in the store and add edit links plus status messaging to the listing views

## Testing
- not run (tests not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d3baa4fdd08322bb818ee25da4a33e