### PR TITLE
Fix error page navigation links

### DIFF
--- a/Recipe/src/lib/navigation.js
+++ b/Recipe/src/lib/navigation.js
@@ -1,0 +1,64 @@
+const constants = require('./constants');
+const { sanitiseString } = require('./utils');
+
+const APP_ID = constants.APP_ID;
+const USER_ID_REGEX = /^U-\d{5}$/;
+
+function normaliseUserId(value) {
+  const trimmed = sanitiseString(value).toUpperCase();
+  return USER_ID_REGEX.test(trimmed) ? trimmed : '';
+}
+
+function extractUserIdFromReferer(header) {
+  const ref = sanitiseString(header);
+  if (!ref) {
+    return '';
+  }
+  try {
+    const parsed = new URL(ref, 'http://localhost');
+    return normaliseUserId(parsed.searchParams.get('userId'));
+  } catch (err) {
+    return '';
+  }
+}
+
+function resolveUserId(req) {
+  if (!req) {
+    return '';
+  }
+
+  const fromQuery = normaliseUserId(req.query && req.query.userId);
+  if (fromQuery) {
+    return fromQuery;
+  }
+
+  const fromBody = normaliseUserId(req.body && req.body.userId);
+  if (fromBody) {
+    return fromBody;
+  }
+
+  const refererHeader = req.headers && (req.headers.referer || req.headers.referrer);
+  return extractUserIdFromReferer(refererHeader);
+}
+
+function buildReturnLink(req) {
+  const userId = resolveUserId(req);
+  if (userId) {
+    return {
+      href: '/home-' + APP_ID + '?userId=' + encodeURIComponent(userId),
+      text: 'Return to Home',
+      userId: userId,
+    };
+  }
+
+  return {
+    href: '/login-' + APP_ID,
+    text: 'Go to Login',
+    userId: '',
+  };
+}
+
+module.exports = {
+  buildReturnLink: buildReturnLink,
+  resolveUserId: resolveUserId,
+};

--- a/Recipe/src/middleware/notFound.js
+++ b/Recipe/src/middleware/notFound.js
@@ -1,14 +1,20 @@
-const path = require('path');
+const navigation = require('../lib/navigation');
+const { sanitiseString } = require('../lib/utils');
 
 function notFound(req, res) {
   if (req.accepts('html')) {
-    return res
-      .status(404)
-      .sendFile(path.join(__dirname, '..', 'views', '404.html'));  
+    const link = navigation.buildReturnLink(req);
+    const requestedPath = sanitiseString(req.originalUrl || req.path || '');
+    return res.status(404).render('404.html', {
+      returnHref: link.href,
+      returnText: link.text,
+      userId: link.userId,
+      requestedPath: requestedPath,
+    });
   }
   return res
     .status(404)
     .json({ error: 'Not Found', path: req.originalUrl });
-  }
+}
 
 module.exports = notFound;

--- a/Recipe/src/routes/inventory.js
+++ b/Recipe/src/routes/inventory.js
@@ -4,6 +4,7 @@ const constants = require('../lib/constants');
 const APP_ID = constants.APP_ID;
 const store = require('../store');
 const ValidationError = require('../errors/ValidationError');
+const navigation = require('../lib/navigation');
 
 const CREATE_PATH = '/add-inventory-' + APP_ID;
 const LIST_PATH = '/inventory-dashboard-' + APP_ID;
@@ -409,7 +410,16 @@ router.post(UPDATE_PATH, async function (req, res, next) {
   } catch (err) {
     const mapped = normaliseError(err);
     if (mapped instanceof ValidationError && clientWantsHtml(req)) {
-      return res.redirect(302, '/invalid.html');
+      const link = navigation.buildReturnLink(req);
+      const message = mapped.errors && mapped.errors.length
+        ? mapped.errors.join(' ')
+        : 'There was a problem with the submitted data.';
+      return res.status(400).render('invalid.html', {
+        message: message,
+        returnHref: link.href,
+        returnText: link.text,
+        userId: link.userId,
+      });
     }
     return next(mapped);
   }

--- a/Recipe/src/views/404.html
+++ b/Recipe/src/views/404.html
@@ -10,6 +10,14 @@
   </head>
   <body>
     <h1>404 Page not found</h1>
-    <p><a href="/home-31477046">Return to Home</a></p>
+    <% if (requestedPath) { %>
+      <p>The page <code><%= requestedPath %></code> could not be found.</p>
+    <% } else { %>
+      <p>The page you requested could not be found.</p>
+    <% } %>
+    <p><a href="<%= returnHref %>"><%= returnText %></a></p>
+    <% if (!userId) { %>
+      <p>You may need to log in again to access your dashboard.</p>
+    <% } %>
   </body>
 </html>

--- a/Recipe/src/views/invalid.html
+++ b/Recipe/src/views/invalid.html
@@ -10,7 +10,10 @@
   </head>
   <body>
     <h1>Invalid data</h1>
-    <p>Something about the request wasn’t valid. Please go back and check the input.</p>
-    <p><a href="/home-31477046">Return to Home</a></p>
+    <p><%= message || 'Something about the request wasn’t valid. Please go back and check the input.' %></p>
+    <p><a href="<%= returnHref %>"><%= returnText %></a></p>
+    <% if (!userId) { %>
+      <p>You may need to log in again to continue.</p>
+    <% } %>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add a navigation helper to determine the appropriate return link for friendly pages
- render 404 and invalid templates with dynamic messaging and smarter navigation targets
- update middleware and inventory routes to use the helper so users return to their dashboard when possible

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68d3c210a6bc8322b5f28231014ab01b