### PR TITLE
refactor: centralize shared page styles

### DIFF
--- a/Recipe/src/css/pages.css
+++ b/Recipe/src/css/pages.css
@@ -1,0 +1,85 @@
+/* Shared utility classes */
+.mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+}
+
+/* Dashboard page */
+body.dashboard-page {
+  margin: 0;
+  background-color: #f5f6f8;
+}
+
+.dashboard-page .navbar .dropdown-toggle::after {
+  margin-left: 0.35rem;
+}
+
+.dashboard-page .quick-actions .card {
+  border: none;
+  border-radius: 1rem;
+  box-shadow: 0 0.25rem 0.75rem rgba(18, 38, 63, 0.08);
+}
+
+.dashboard-page .quick-actions .card-title {
+  font-weight: 600;
+  font-size: 1.2rem;
+}
+
+.dashboard-page .quick-actions .card-text {
+  color: #6c757d;
+}
+
+/* Inventory dashboard */
+body.inventory-dashboard-page {
+  padding: 2rem;
+}
+
+.inventory-dashboard-page .status-badge {
+  padding: 0.2rem 0.45rem;
+  border-radius: 0.35rem;
+  font-size: 12px;
+}
+
+.inventory-dashboard-page .status-expired {
+  background: #f8d7da;
+  color: #842029;
+}
+
+.inventory-dashboard-page .status-soon {
+  background: #fff3cd;
+  color: #664d03;
+}
+
+.inventory-dashboard-page .status-ok {
+  background: #d1e7dd;
+  color: #0f5132;
+}
+
+.inventory-dashboard-page .status-unknown {
+  background: #e2e3e5;
+  color: #41464b;
+}
+
+/* Recipes list */
+body.recipes-list-page {
+  padding: 2rem;
+}
+
+.recipes-list-page table {
+  font-size: 14px;
+}
+
+.recipes-list-page td pre {
+  margin: 0;
+  white-space: pre-wrap;
+}
+
+/* Full-page message layouts (404, invalid, etc.) */
+body.message-page {
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif;
+  text-align: center;
+  padding: 10vh 2rem;
+}
+
+.message-page a {
+  text-decoration: none;
+}

--- a/Recipe/src/views/404.html
+++ b/Recipe/src/views/404.html
@@ -3,12 +3,9 @@
   <head>
     <meta charset="utf-8" />
     <title>404 - Page Not Found</title>
-    <style>
-      body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; text-align:center; padding: 10vh 2rem; }
-      a { text-decoration: none; }
-    </style>
+    <link rel="stylesheet" href="/pages.css" />
   </head>
-  <body>
+  <body class="message-page">
     <h1>404 Page not found</h1>
     <% if (requestedPath) { %>
       <p>The page <code><%= requestedPath %></code> could not be found.</p>

--- a/Recipe/src/views/index.html
+++ b/Recipe/src/views/index.html
@@ -4,33 +4,9 @@
     <meta charset="utf-8" />
     <title>Recipe Hub - Dashboard</title>
     <link rel="stylesheet" href="/bootstrap.min.css" />
-    <style>
-      body {
-        margin: 0;
-        background-color: #f5f6f8;
-      }
-
-      .navbar .dropdown-toggle::after {
-        margin-left: 0.35rem;
-      }
-
-      .quick-actions .card {
-        border: none;
-        border-radius: 1rem;
-        box-shadow: 0 0.25rem 0.75rem rgba(18, 38, 63, 0.08);
-      }
-
-      .quick-actions .card-title {
-        font-weight: 600;
-        font-size: 1.2rem;
-      }
-
-      .quick-actions .card-text {
-        color: #6c757d;
-      }
-    </style>
+    <link rel="stylesheet" href="/pages.css" />
   </head>
-  <body>
+  <body class="dashboard-page">
     <nav class="navbar navbar-expand-lg bg-primary navbar-dark">
       <div class="container-fluid">
         <a class="navbar-brand" href="/home-<%= appId %>?userId=<%= id %>">Recipe Hub</a>

--- a/Recipe/src/views/invalid.html
+++ b/Recipe/src/views/invalid.html
@@ -3,12 +3,9 @@
   <head>
     <meta charset="utf-8" />
     <title>Invalid Data</title>
-    <style>
-      body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; text-align:center; padding: 10vh 2rem; }
-      a { text-decoration: none; }
-    </style>
+    <link rel="stylesheet" href="/pages.css" />
   </head>
-  <body>
+  <body class="message-page">
     <h1>Invalid data</h1>
     <p><%= message || 'Something about the request wasn’t valid. Please go back and check the input.' %></p>
     <p><a href="<%= returnHref %>"><%= returnText %></a></p>

--- a/Recipe/src/views/inventory-dashboard-31477046.html
+++ b/Recipe/src/views/inventory-dashboard-31477046.html
@@ -4,17 +4,9 @@
     <meta charset="utf-8" />
     <title>Inventory - Dashboard</title>
     <link rel="stylesheet" href="/bootstrap.min.css" />
-    <style>
-      body { padding: 2rem; }
-      .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
-      .status-badge { padding: 0.2rem 0.45rem; border-radius: 0.35rem; font-size: 12px; }
-      .status-expired { background: #f8d7da; color: #842029; }
-      .status-soon { background: #fff3cd; color: #664d03; }
-      .status-ok { background: #d1e7dd; color: #0f5132; }
-      .status-unknown { background: #e2e3e5; color: #41464b; }
-    </style>
+    <link rel="stylesheet" href="/pages.css" />
   </head>
-  <body>
+  <body class="inventory-dashboard-page">
     <div class="container">
       <div class="mb-3">
         <a class="btn btn-outline-primary" href="/home-<%= appId %>?userId=<%= userId %>">Return to Home</a>

--- a/Recipe/src/views/recipes-list-31477046.html
+++ b/Recipe/src/views/recipes-list-31477046.html
@@ -4,14 +4,9 @@
     <meta charset="utf-8" />
     <title>Recipes - List</title>
     <link rel="stylesheet" href="/bootstrap.min.css" />
-    <style>
-      body { padding: 2rem; }
-      table { font-size: 14px; }
-      .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
-      td pre { margin: 0; white-space: pre-wrap; }
-    </style>
+    <link rel="stylesheet" href="/pages.css" />
   </head>
-  <body>
+  <body class="recipes-list-page">
     <div class="container">
       <div class="mb-3">
         <a class="btn btn-outline-primary" href="/home-<%= appId %>?userId=<%= userId %>">Return to Home</a>


### PR DESCRIPTION
## Summary
- add a shared `pages.css` stylesheet that contains the reusable layout rules for dashboard, list, inventory, and message pages
- update the affected views to import the consolidated stylesheet and apply page-specific body classes instead of inline `<style>` tags

## Testing
- not run (no automated tests provided)


------
https://chatgpt.com/codex/tasks/task_e_68d4c1db90c48322903499d4be95c583