### PR TITLE
Serve Bootstrap bundle locally for navbar

### DIFF
--- a/Recipe/src/server.js
+++ b/Recipe/src/server.js
@@ -53,6 +53,10 @@ app.use('/bootstrap', express.static(
   path.join(__dirname, '../node_modules/bootstrap/dist/css/bootstrap.min.css')
 ));
 
+app.get('/bootstrap.bundle.min.js', function (req, res) {
+  res.sendFile(path.join(__dirname, '../node_modules/bootstrap/dist/js/bootstrap.bundle.min.js'));
+});
+
 app.set('views', path.join(__dirname, 'views'));
 app.engine('html', require('ejs').renderFile);
 app.set('view engine', 'html');

--- a/Recipe/src/views/index.html
+++ b/Recipe/src/views/index.html
@@ -169,6 +169,6 @@
         <p>Built by <%= username %> (Student ID: <%= appId %>)</p>
       </footer>
     </div>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-w76A2z02tPqdjfq6w0l0F8EwQ0nPEzvFZV6jDQm9Kl8yYh7vHk/tz1FQ0bOSGb12" crossorigin="anonymous"></script>
+    <script src="/bootstrap.bundle.min.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- expose Bootstrap's bundled JavaScript from the server so data attributes such as dropdowns work without CDN access
- update the dashboard view to load the locally-served Bootstrap bundle instead of the remote CDN script

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4c411db308322b23404a5a4cc7ec2