### PR TITLE
Add analytics pipelines for recipe recommendations and inventory insights

### DIFF
--- a/Recipe/src/models/InventoryItem.js
+++ b/Recipe/src/models/InventoryItem.js
@@ -132,6 +132,9 @@ inventorySchema.pre('save', function (next) {
   next();
 });
 
+inventorySchema.index({ ingredientName: 1, userId: 1 });
+inventorySchema.index({ expirationDate: 1 });
+
 module.exports = mongoose.model('InventoryItem', inventorySchema);
 
 

--- a/Recipe/src/models/Recipe.js
+++ b/Recipe/src/models/Recipe.js
@@ -147,6 +147,8 @@ const recipeSchema = new mongoose.Schema({
 });
 
 recipeSchema.index({ userId: 1, title: 1 }, { unique: true });
+recipeSchema.index({ userId: 1 });
+recipeSchema.index({ 'ingredients.ingredientName': 1 });
 
 recipeSchema.pre('save', function (next) {
   this.updatedAt = new Date();

--- a/Recipe/src/routes/analytics.js
+++ b/Recipe/src/routes/analytics.js
@@ -1,0 +1,108 @@
+const express = require('express');
+const router = express.Router();
+const constants = require('../lib/constants');
+const APP_ID = constants.APP_ID;
+const store = require('../store');
+
+const RECOMMEND_PATH = '/analytics/recipe-recommendations-' + APP_ID;
+const NUTRITION_PATH = '/analytics/recipe-nutrition-' + APP_ID;
+const OPTIMISATION_PATH = '/analytics/inventory-optimisation-' + APP_ID;
+
+function parseNumber(value, defaultValue) {
+  const parsed = Number(value);
+  if (Number.isFinite(parsed)) {
+    return parsed;
+  }
+  return defaultValue;
+}
+
+function parseUserId(value) {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim().toUpperCase();
+  return trimmed || null;
+}
+
+router.get(RECOMMEND_PATH, async function (req, res, next) {
+  try {
+    const query = req.query || {};
+    const options = {};
+
+    const recipeUserId = parseUserId(query.userId);
+    if (recipeUserId) {
+      options.userId = recipeUserId;
+    }
+
+    const inventoryUserId = parseUserId(query.inventoryUserId);
+    if (inventoryUserId) {
+      options.inventoryUserId = inventoryUserId;
+    }
+
+    const minScore = parseNumber(query.minScore, null);
+    if (minScore !== null) {
+      options.minScore = minScore;
+    }
+
+    const limit = parseInt(query.limit, 10);
+    if (Number.isFinite(limit) && limit > 0) {
+      options.limit = limit;
+    }
+
+    const recommendations = await store.recommendRecipesFromInventory(options);
+    return res.json({ recommendations });
+  } catch (err) {
+    return next(err);
+  }
+});
+
+router.get(NUTRITION_PATH, async function (req, res, next) {
+  try {
+    const query = req.query || {};
+    const options = {};
+
+    const userId = parseUserId(query.userId);
+    if (userId) {
+      options.userId = userId;
+    }
+
+    const topLimit = parseInt(query.topIngredientsLimit, 10);
+    if (Number.isFinite(topLimit) && topLimit > 0) {
+      options.topIngredientsLimit = topLimit;
+    }
+
+    const summary = await store.getRecipeNutritionSummary(options);
+    return res.json({ summary });
+  } catch (err) {
+    return next(err);
+  }
+});
+
+router.get(OPTIMISATION_PATH, async function (req, res, next) {
+  try {
+    const query = req.query || {};
+    const options = {};
+
+    const userId = parseUserId(query.userId);
+    if (userId) {
+      options.userId = userId;
+    }
+
+    const threshold = parseNumber(query.lowStockThreshold, null);
+    if (threshold !== null) {
+      options.lowStockThreshold = threshold;
+    }
+
+    const expiringSoon = parseNumber(query.expiringSoonDays, null);
+    if (expiringSoon !== null) {
+      options.expiringSoonDays = expiringSoon;
+    }
+
+    const suggestions = await store.getInventoryOptimisationSuggestions(options);
+    return res.json({ suggestions });
+  } catch (err) {
+    return next(err);
+  }
+});
+
+module.exports = router;

--- a/Recipe/src/routes/index.js
+++ b/Recipe/src/routes/index.js
@@ -2,8 +2,10 @@ const express = require('express');
 const router = express.Router();
 const recipesRouter = require('./recipes');
 const inventoryRouter = require('./inventory');
+const analyticsRouter = require('./analytics');
 
 router.use(recipesRouter);
 router.use(inventoryRouter);
+router.use(analyticsRouter);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- add dedicated analytics routes that expose recipe recommendations, nutrition summaries, and inventory optimisation reports
- build aggregation pipelines that join recipes with inventory, summarise ingredient usage, and surface low-stock or expiring ingredients
- index frequent query fields on recipes and inventory for faster analytics lookups

## Testing
- `node -e "require('./Recipe/src/store'); console.log('store ok');"`


------
https://chatgpt.com/codex/tasks/task_e_68d4c59802fc8322898ea5d3ccf93b13