### PR TITLE
Implement role-based access controls and chef dashboard

### DIFF
--- a/Recipe/src/lib/auth.js
+++ b/Recipe/src/lib/auth.js
@@ -5,7 +5,8 @@ function buildLoginRedirectUrl(appId, message) {
   return '/login-' + appId + '?error=' + encodeURIComponent(text);
 }
 
-async function resolveActiveUser(req, store) {
+async function resolveActiveUser(req, store, options) {
+  const opts = options || {};
   const queryUserId = sanitiseString(req.query && req.query.userId);
   const bodyUserId = sanitiseString(req.body && req.body.userId);
   const sourceId = queryUserId || bodyUserId;
@@ -23,6 +24,17 @@ async function resolveActiveUser(req, store) {
 
   if (!user.isLoggedIn) {
     return { error: 'Your session has ended. Please log in again.' };
+  }
+
+  if (Array.isArray(opts.allowedRoles) && opts.allowedRoles.length) {
+    const role = (user.role || '').toString().toLowerCase();
+    const allowed = opts.allowedRoles.some(function (allowedRole) {
+      return (allowedRole || '').toString().toLowerCase() === role;
+    });
+
+    if (!allowed) {
+      return { error: 'You are not allowed to access this page.' };
+    }
   }
 
   return { user: user };

--- a/Recipe/src/lib/permissions.js
+++ b/Recipe/src/lib/permissions.js
@@ -1,0 +1,45 @@
+const ALLOWED_INVENTORY_ROLES = ['chef', 'manager', 'admin'];
+
+function normaliseRole(value) {
+  return (value || '').toString().trim().toLowerCase();
+}
+
+function userCanAccessRecipes(user) {
+  return normaliseRole(user && user.role) === 'chef';
+}
+
+function userCanViewRecipe(user, recipe) {
+  if (!userCanAccessRecipes(user)) {
+    return false;
+  }
+
+  if (!recipe) {
+    return true;
+  }
+
+  return true;
+}
+
+function userCanModifyRecipe(user, recipe) {
+  if (!userCanAccessRecipes(user)) {
+    return false;
+  }
+
+  if (!recipe) {
+    return false;
+  }
+
+  return recipe.userId === user.userId;
+}
+
+function userCanAccessInventory(user) {
+  const role = normaliseRole(user && user.role);
+  return ALLOWED_INVENTORY_ROLES.indexOf(role) !== -1;
+}
+
+module.exports = {
+  userCanAccessRecipes,
+  userCanViewRecipe,
+  userCanModifyRecipe,
+  userCanAccessInventory
+};

--- a/Recipe/src/models/InventoryItem.js
+++ b/Recipe/src/models/InventoryItem.js
@@ -48,6 +48,12 @@ const inventorySchema = new mongoose.Schema({
       message: 'User Id must exist before creating an inventory item.'
     }
   },
+  user: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',
+    required: true,
+    index: true
+  },
   ingredientName: {
     type: String,
     required: true,
@@ -131,6 +137,9 @@ inventorySchema.pre('save', function (next) {
   this.updatedAt = new Date();
   next();
 });
+
+inventorySchema.index({ inventoryId: 1 });
+inventorySchema.index({ userId: 1 });
 
 module.exports = mongoose.model('InventoryItem', inventorySchema);
 

--- a/Recipe/src/models/Recipe.js
+++ b/Recipe/src/models/Recipe.js
@@ -61,6 +61,12 @@ const recipeSchema = new mongoose.Schema({
       message: 'User Id must exist before creating a recipe.'
     }
   },
+  user: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',
+    required: true,
+    index: true
+  },
   title: {
     type: String,
     required: true,
@@ -147,6 +153,8 @@ const recipeSchema = new mongoose.Schema({
 });
 
 recipeSchema.index({ userId: 1, title: 1 }, { unique: true });
+recipeSchema.index({ recipeId: 1 });
+recipeSchema.index({ userId: 1 });
 
 recipeSchema.pre('save', function (next) {
   this.updatedAt = new Date();

--- a/Recipe/src/models/User.js
+++ b/Recipe/src/models/User.js
@@ -79,6 +79,10 @@ userSchema.pre('save', function (next) {
   next();
 });
 
+userSchema.index({ email: 1 });
+userSchema.index({ userId: 1 });
+userSchema.index({ role: 1 });
+
 module.exports = mongoose.model('User', userSchema);
 
 

--- a/Recipe/src/views/index.html
+++ b/Recipe/src/views/index.html
@@ -26,69 +26,75 @@
             <li class="nav-item">
               <a class="nav-link active" href="/home-<%= appId %>?userId=<%= id %>">Home</a>
             </li>
-            <li class="nav-item dropdown">
-              <a
-                class="nav-link dropdown-toggle"
-                href="#"
-                id="recipesDropdown"
-                role="button"
-                data-bs-toggle="dropdown"
-                aria-expanded="false"
-              >
-                Recipes
-              </a>
-              <ul class="dropdown-menu" aria-labelledby="recipesDropdown">
-                <li>
-                  <a class="dropdown-item" href="/recipes-list-<%= appId %>?userId=<%= id %>">All Recipes</a>
-                </li>
-                <li>
-                  <a class="dropdown-item" href="/add-recipe-<%= appId %>?userId=<%= id %>">Add Recipe</a>
-                </li>
-                <li>
-                  <a class="dropdown-item" href="/delete-recipe-<%= appId %>?userId=<%= id %>">Delete Recipe</a>
-                </li>
-              </ul>
-            </li>
-            <li class="nav-item dropdown">
-              <a
-                class="nav-link dropdown-toggle"
-                href="#"
-                id="inventoryDropdown"
-                role="button"
-                data-bs-toggle="dropdown"
-                aria-expanded="false"
-              >
-                Inventory
-              </a>
-              <ul class="dropdown-menu" aria-labelledby="inventoryDropdown">
-                <li>
-                  <a class="dropdown-item" href="/inventory-dashboard-<%= appId %>?userId=<%= id %>">Inventory Dashboard</a>
-                </li>
-                <li>
-                  <a class="dropdown-item" href="/add-inventory-<%= appId %>?userId=<%= id %>">Add Inventory Item</a>
-                </li>
-                <li>
-                  <a class="dropdown-item" href="/delete-inventory-<%= appId %>?userId=<%= id %>">Delete Inventory</a>
-                </li>
-              </ul>
-            </li>
-            <li class="nav-item dropdown">
-              <a
-                class="nav-link dropdown-toggle"
-                href="#"
-                id="hdTasksDropdown"
-                role="button"
-                data-bs-toggle="dropdown"
-                aria-expanded="false"
-              >
-                HD Tasks
-              </a>
-              <ul class="dropdown-menu" aria-labelledby="hdTasksDropdown">
-                <li>
-                  <a class="dropdown-item" href="/hd-task1-<%= appId %>?userId=<%= id %>">Recipe Recommendations</a>
-                </li>
-              </ul>
-            </li>
+            <% if (canManageRecipes) { %>
+              <li class="nav-item dropdown">
+                <a
+                  class="nav-link dropdown-toggle"
+                  href="#"
+                  id="recipesDropdown"
+                  role="button"
+                  data-bs-toggle="dropdown"
+                  aria-expanded="false"
+                >
+                  Recipes
+                </a>
+                <ul class="dropdown-menu" aria-labelledby="recipesDropdown">
+                  <li>
+                    <a class="dropdown-item" href="/recipes-list-<%= appId %>?userId=<%= id %>">All Recipes</a>
+                  </li>
+                  <li>
+                    <a class="dropdown-item" href="/add-recipe-<%= appId %>?userId=<%= id %>">Add Recipe</a>
+                  </li>
+                  <li>
+                    <a class="dropdown-item" href="/delete-recipe-<%= appId %>?userId=<%= id %>">Delete Recipe</a>
+                  </li>
+                </ul>
+              </li>
+            <% } %>
+            <% if (canManageInventory) { %>
+              <li class="nav-item dropdown">
+                <a
+                  class="nav-link dropdown-toggle"
+                  href="#"
+                  id="inventoryDropdown"
+                  role="button"
+                  data-bs-toggle="dropdown"
+                  aria-expanded="false"
+                >
+                  Inventory
+                </a>
+                <ul class="dropdown-menu" aria-labelledby="inventoryDropdown">
+                  <li>
+                    <a class="dropdown-item" href="/inventory-dashboard-<%= appId %>?userId=<%= id %>">Inventory Dashboard</a>
+                  </li>
+                  <li>
+                    <a class="dropdown-item" href="/add-inventory-<%= appId %>?userId=<%= id %>">Add Inventory Item</a>
+                  </li>
+                  <li>
+                    <a class="dropdown-item" href="/delete-inventory-<%= appId %>?userId=<%= id %>">Delete Inventory</a>
+                  </li>
+                </ul>
+              </li>
+            <% } %>
+            <% if (canManageRecipes) { %>
+              <li class="nav-item dropdown">
+                <a
+                  class="nav-link dropdown-toggle"
+                  href="#"
+                  id="hdTasksDropdown"
+                  role="button"
+                  data-bs-toggle="dropdown"
+                  aria-expanded="false"
+                >
+                  HD Tasks
+                </a>
+                <ul class="dropdown-menu" aria-labelledby="hdTasksDropdown">
+                  <li>
+                    <a class="dropdown-item" href="/hd-task1-<%= appId %>?userId=<%= id %>">Recipe Recommendations</a>
+                  </li>
+                </ul>
+              </li>
+            <% } %>
           </ul>
         </div>
         <div class="d-flex align-items-center text-white">
@@ -96,6 +102,7 @@
             <div>Welcome, <%= username %></div>
             <small class="d-block">Email: <%= email %></small>
             <small class="d-block">ID: <%= id %></small>
+            <small class="d-block text-uppercase">Role: <%= role %></small>
           </div>
           <form class="d-flex" method="post" action="/logout-<%= appId %>">
             <input type="hidden" name="userId" value="<%= id %>" />
@@ -156,31 +163,113 @@
 
       <h2 class="text-center mb-3">Quick Actions</h2>
       <div class="row quick-actions g-3 justify-content-center">
-        <div class="col-md-6 col-lg-5">
-          <div class="card h-100">
-            <div class="card-body">
-              <h3 class="card-title">Recipe Management</h3>
-              <p class="card-text">Create, view, and manage your recipes.</p>
-              <div class="d-flex flex-wrap gap-2">
-                <a class="btn btn-primary" href="/add-recipe-<%= appId %>?userId=<%= id %>">Add Recipe</a>
-                <a class="btn btn-outline-primary" href="/recipes-list-<%= appId %>?userId=<%= id %>">View Recipes</a>
+        <% if (canManageRecipes) { %>
+          <div class="col-md-6 col-lg-5">
+            <div class="card h-100">
+              <div class="card-body">
+                <h3 class="card-title">Recipe Management</h3>
+                <p class="card-text">Create, view, and manage your recipes.</p>
+                <div class="d-flex flex-wrap gap-2">
+                  <a class="btn btn-primary" href="/add-recipe-<%= appId %>?userId=<%= id %>">Add Recipe</a>
+                  <a class="btn btn-outline-primary" href="/recipes-list-<%= appId %>?userId=<%= id %>">View Recipes</a>
+                </div>
               </div>
             </div>
           </div>
-        </div>
-        <div class="col-md-6 col-lg-5">
-          <div class="card h-100">
-            <div class="card-body">
-              <h3 class="card-title">Inventory Management</h3>
-              <p class="card-text">Track and manage your inventory items.</p>
-              <div class="d-flex flex-wrap gap-2">
-                <a class="btn btn-success" href="/add-inventory-<%= appId %>?userId=<%= id %>">Add Item</a>
-                <a class="btn btn-outline-success" href="/inventory-dashboard-<%= appId %>?userId=<%= id %>">View Inventory</a>
+        <% } %>
+        <% if (canManageInventory) { %>
+          <div class="col-md-6 col-lg-5">
+            <div class="card h-100">
+              <div class="card-body">
+                <h3 class="card-title">Inventory Management</h3>
+                <p class="card-text">Track and manage your inventory items.</p>
+                <div class="d-flex flex-wrap gap-2">
+                  <a class="btn btn-success" href="/add-inventory-<%= appId %>?userId=<%= id %>">Add Item</a>
+                  <a class="btn btn-outline-success" href="/inventory-dashboard-<%= appId %>?userId=<%= id %>">View Inventory</a>
+                </div>
               </div>
             </div>
           </div>
-        </div>
+        <% } %>
       </div>
+
+      <% if (canManageRecipes) { %>
+        <section class="mt-4">
+          <h2 class="mb-3">My Recipes</h2>
+          <% if (Array.isArray(myRecipes) && myRecipes.length) { %>
+            <ul class="list-group mb-3">
+              <% myRecipes.forEach(function(recipe) { %>
+                <li class="list-group-item d-flex justify-content-between align-items-start">
+                  <div>
+                    <strong><%= recipe.title %></strong>
+                    <div class="text-muted small">ID: <%= recipe.recipeId %> · Cuisine: <%= recipe.cuisineType %></div>
+                  </div>
+                  <a class="btn btn-sm btn-outline-primary" href="/recipes/<%= recipe.recipeId %>-<%= appId %>?userId=<%= id %>">View</a>
+                </li>
+              <% }); %>
+            </ul>
+          <% } else { %>
+            <p class="text-muted">You have not added any recipes yet. Start by creating one above.</p>
+          <% } %>
+        </section>
+
+        <section class="mt-4">
+          <h2 class="mb-3">Inventory-Based Suggestions</h2>
+          <% if (Array.isArray(recipeSuggestions) && recipeSuggestions.length) { %>
+            <div class="list-group mb-3">
+              <% recipeSuggestions.forEach(function(suggestion) { %>
+                <div class="list-group-item">
+                  <div class="d-flex justify-content-between align-items-center">
+                    <div>
+                      <strong><%= suggestion.title %></strong>
+                      <div class="small text-muted">Match Score: <%= suggestion.cookabilityScore %>%</div>
+                    </div>
+                    <span class="badge bg-primary rounded-pill"><%= suggestion.matchedCount %>/<%= suggestion.totalIngredients %> ingredients on hand</span>
+                  </div>
+                  <% if (suggestion.missingIngredients && suggestion.missingIngredients.length) { %>
+                    <div class="small mt-2">Missing: <%= suggestion.missingIngredients.join(', ') %></div>
+                  <% } %>
+                </div>
+              <% }); %>
+            </div>
+          <% } else { %>
+            <p class="text-muted">No recipe suggestions available yet. Keep building your shared inventory.</p>
+          <% } %>
+        </section>
+      <% } %>
+
+      <% if (canManageInventory) { %>
+        <section class="mt-4">
+          <h2 class="mb-3">Shared Inventory Highlights</h2>
+          <% if (Array.isArray(sharedInventory) && sharedInventory.length) { %>
+            <div class="table-responsive">
+              <table class="table table-sm table-striped">
+                <thead>
+                  <tr>
+                    <th scope="col">Ingredient</th>
+                    <th scope="col">Quantity</th>
+                    <th scope="col">Category</th>
+                    <th scope="col">Expires</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <% sharedInventory.forEach(function(item) { %>
+                    <% const expiryDate = item && item.expirationDate ? new Date(item.expirationDate) : null; %>
+                    <tr>
+                      <td><%= item.ingredientName %></td>
+                      <td><%= item.quantity %> <%= item.unit %></td>
+                      <td><%= item.category %></td>
+                      <td><%= expiryDate && !isNaN(expiryDate.getTime()) ? expiryDate.toISOString().split('T')[0] : '—' %></td>
+                    </tr>
+                  <% }); %>
+                </tbody>
+              </table>
+            </div>
+          <% } else { %>
+            <p class="text-muted">No shared inventory items available yet. Add an item to get started.</p>
+          <% } %>
+        </section>
+      <% } %>
       <footer class="text-center mt-4">
         <p>Recipe Hub - FTT2095 Assignment 1</p>
         <p>Built by <%= username %> (Student ID: <%= appId %>)</p>


### PR DESCRIPTION
## Summary
- add a permissions helper and update recipe and inventory routes plus views to enforce chef-only recipe access and authorised inventory management
- link recipes and inventory items directly to users with reference fields, validation, and seeding support for consistent ownership checks
- enhance the home dashboard with role-aware navigation, personal recipe and suggestion panels for chefs, and shared inventory highlights for all authorised roles

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68d4e0281cd48322ac7d3dfe7c8e2899