### PR TITLE
Add explanatory comments to form helper modules

### DIFF
--- a/Recipe/src/forms/inventoryForm.js
+++ b/Recipe/src/forms/inventoryForm.js
@@ -9,6 +9,7 @@ const {
 } = require('../lib/validationConstants');
 const { toIsoDate } = require('../lib/date');
 
+// Default values used to reset the inventory form when no data is provided.
 const EMPTY_INVENTORY_FORM_VALUES = {
   inventoryId: '',
   userId: '',
@@ -23,10 +24,12 @@ const EMPTY_INVENTORY_FORM_VALUES = {
   createdDate: ''
 };
 
+// Returns a fresh copy of the empty inventory form object so callers don't mutate the template.
 function getEmptyInventoryFormValues() {
   return Object.assign({}, EMPTY_INVENTORY_FORM_VALUES);
 }
 
+// Converts raw request body data into a normalised inventory item with correctly typed fields.
 function parseInventoryForm(body) {
   const item = {};
   item.inventoryId = (body.inventoryId || '').trim();
@@ -44,6 +47,7 @@ function parseInventoryForm(body) {
   return item;
 }
 
+// Validates a normalised inventory item and returns any validation messages to show the user.
 function collectInventoryErrors(item) {
   const errors = [];
   if (!item) {
@@ -99,11 +103,13 @@ function collectInventoryErrors(item) {
     errors.push('Cost must be between 0.01 and 999.99.');
   } else {
     const cents = Math.round(cost * 100);
+    // Guard against floating point rounding problems when checking for two decimal places.
     if (Math.abs(cost * 100 - cents) > 1e-6) {
       errors.push('Cost must have no more than two decimal places.');
     }
   }
 
+  // Support both Date objects and strings by converting anything that's not already a Date.
   const purchaseDate = item.purchaseDate instanceof Date ? item.purchaseDate : new Date(item.purchaseDate);
   if (!(purchaseDate instanceof Date) || Number.isNaN(purchaseDate.getTime())) {
     errors.push('Purchase date must be a valid date.');
@@ -111,6 +117,7 @@ function collectInventoryErrors(item) {
     errors.push('Purchase date cannot be in the future.');
   }
 
+  // Reuse the same "accept Date or string" logic for expiration checks.
   const expirationDate = item.expirationDate instanceof Date ? item.expirationDate : new Date(item.expirationDate);
   if (!(expirationDate instanceof Date) || Number.isNaN(expirationDate.getTime())) {
     errors.push('Expiration date must be a valid date.');
@@ -118,6 +125,7 @@ function collectInventoryErrors(item) {
     errors.push('Expiration date must be after the purchase date.');
   }
 
+  // Created date also needs to become a Date object before validation.
   const createdDate = item.createdDate instanceof Date ? item.createdDate : new Date(item.createdDate);
   if (!(createdDate instanceof Date) || Number.isNaN(createdDate.getTime())) {
     errors.push('Created date must be a valid date.');
@@ -128,6 +136,7 @@ function collectInventoryErrors(item) {
   return errors;
 }
 
+// Takes an inventory record and builds the values to show when re-rendering the form.
 function buildInventoryFormValuesFromItem(item) {
   const values = getEmptyInventoryFormValues();
   if (!item) {
@@ -147,6 +156,7 @@ function buildInventoryFormValuesFromItem(item) {
 
   const costNumber = Number(item.cost);
   if (Number.isFinite(costNumber)) {
+    // Round to cents and force two decimal places so the input shows a money-friendly value.
     values.cost = (Math.round(costNumber * 100) / 100).toFixed(2);
   } else {
     values.cost = '';
@@ -159,11 +169,13 @@ function buildInventoryFormValuesFromItem(item) {
   return values;
 }
 
+// Prepares inventory data with helper fields (like expiry status) for rendering templates.
 function mapInventoryForView(item) {
   const now = new Date();
   const expiration = item.expirationDate instanceof Date ? item.expirationDate : new Date(item.expirationDate);
   let daysLeft = null;
   if (expiration && !Number.isNaN(expiration.getTime())) {
+    // Convert the millisecond difference into whole days remaining until the item expires.
     const diff = expiration.getTime() - now.getTime();
     daysLeft = Math.ceil(diff / (1000 * 60 * 60 * 24));
   }

--- a/Recipe/src/forms/recipeForm.js
+++ b/Recipe/src/forms/recipeForm.js
@@ -12,6 +12,7 @@ const {
 } = require('../lib/validationConstants');
 const { toIsoDate } = require('../lib/date');
 
+// Template of default values used to clear or initialise the recipe form.
 const EMPTY_RECIPE_FORM_VALUES = {
   recipeId: '',
   title: '',
@@ -26,10 +27,12 @@ const EMPTY_RECIPE_FORM_VALUES = {
   instructionsText: ''
 };
 
+// Provides a brand new copy of the empty form so mutations don't leak between requests.
 function getEmptyRecipeFormValues() {
   return Object.assign({}, EMPTY_RECIPE_FORM_VALUES);
 }
 
+// Attempts to match user input against allowed select options while keeping the original case.
 function normaliseSelectValue(value, options) {
   const trimmed = sanitiseString(value);
   if (!trimmed) {
@@ -43,6 +46,7 @@ function normaliseSelectValue(value, options) {
   return trimmed;
 }
 
+// Normalises raw request body data into strings ready to re-populate the recipe form.
 function buildRecipeFormValuesFromBody(body) {
   const values = getEmptyRecipeFormValues();
   if (!body) {
@@ -62,6 +66,7 @@ function buildRecipeFormValuesFromBody(body) {
   return values;
 }
 
+// Converts a recipe record from the database into form-friendly values (strings and numbers).
 function buildRecipeFormValuesFromRecipe(recipe) {
   const values = getEmptyRecipeFormValues();
   if (!recipe) {
@@ -83,6 +88,7 @@ function buildRecipeFormValuesFromRecipe(recipe) {
 
   values.createdDate = toIsoDate(recipe.createdDate);
 
+  // Turn the structured ingredient objects into text lines the textarea expects.
   const ingredients = Array.isArray(recipe.ingredients) ? recipe.ingredients : [];
   const ingredientLines = [];
   for (let i = 0; i < ingredients.length; i++) {
@@ -96,6 +102,7 @@ function buildRecipeFormValuesFromRecipe(recipe) {
   }
   values.ingredientsText = ingredientLines.join('\n');
 
+  // Clean up each instruction step so the textarea shows one step per line.
   const instructions = Array.isArray(recipe.instructions) ? recipe.instructions : [];
   const instructionLines = [];
   for (let j = 0; j < instructions.length; j++) {
@@ -109,6 +116,7 @@ function buildRecipeFormValuesFromRecipe(recipe) {
   return values;
 }
 
+// Validates every part of a parsed recipe and accumulates user-friendly error messages.
 function collectRecipeErrors(recipe) {
   const errors = [];
 
@@ -229,6 +237,7 @@ function collectRecipeErrors(recipe) {
   return errors;
 }
 
+// Turns submitted form text back into a structured recipe object with numbers and dates.
 function parseRecipeForm(body) {
   const recipe = {};
   const recipeIdInput = sanitiseString(body && body.recipeId);
@@ -253,6 +262,7 @@ function parseRecipeForm(body) {
   for (let i = 0; i < ingLines.length; i++) {
     const line = sanitiseString(ingLines[i]);
     if (!line) continue;
+    // Each line is expected to look like "name | quantity | unit", so split the chunks around the pipes.
     const parts = line.split('|');
     const name = sanitiseString(parts[0]);
     const quantityInput = sanitiseString(parts[1]);
@@ -278,6 +288,7 @@ function parseRecipeForm(body) {
   return recipe;
 }
 
+// Formats the recipe data for templates by ensuring optional lists default to arrays.
 function mapRecipeForView(recipe) {
   return {
     recipeId: recipe.recipeId,

--- a/Recipe/src/forms/userForm.js
+++ b/Recipe/src/forms/userForm.js
@@ -6,6 +6,7 @@ const {
   NAME_REGEX
 } = require('../lib/validationConstants');
 
+// Pulls the relevant registration fields out of the request body and normalises casing.
 function parseRegistrationForm(body) {
   const form = {};
   const emailInput = sanitiseString(body && body.email);
@@ -30,10 +31,12 @@ function parseRegistrationForm(body) {
   return form;
 }
 
+// Removes spaces, parentheses and dashes so phone numbers can be validated consistently.
 function stripPhoneFormatting(value) {
   return (value || '').replace(/[\s()-]/g, '');
 }
 
+// Checks whether a phone number matches the basic Australian formats (with or without +61).
 function isAustralianPhoneNumber(value) {
   const cleaned = stripPhoneFormatting(value);
   if (!cleaned) {
@@ -43,15 +46,18 @@ function isAustralianPhoneNumber(value) {
     if (cleaned.indexOf('+61') !== 0) {
       return false;
     }
+    // After removing the +61 prefix, Australian numbers should be 9 digits starting with the listed ranges.
     const rest = cleaned.slice(3);
     return rest.length === 9 && /^[2-478]\d{8}$/.test(rest);
   }
   if (cleaned.indexOf('0') === 0) {
+    // Local format must start with 0 and have 10 digits total to pass this regex.
     return cleaned.length === 10 && /^[2-478]\d{9}$/.test(cleaned);
   }
   return false;
 }
 
+// Validates the completed registration form and returns any messages to display.
 function collectRegistrationErrors(form) {
   const errors = [];
 
@@ -94,6 +100,7 @@ function collectRegistrationErrors(form) {
   return errors;
 }
 
+// Picks the non-sensitive registration fields for re-rendering the form after validation errors.
 function buildRegistrationValues(form) {
   return {
     email: form.email || '',
@@ -103,6 +110,7 @@ function buildRegistrationValues(form) {
   };
 }
 
+// Extracts only the fields needed for logging in and normalises the email casing.
 function parseLoginForm(body) {
   const form = {};
   const emailInput = sanitiseString(body && body.email);
@@ -115,6 +123,7 @@ function parseLoginForm(body) {
   return form;
 }
 
+// Performs simple validation on the login form before attempting authentication.
 function collectLoginErrors(form) {
   const errors = [];
 


### PR DESCRIPTION
## Summary
- add high-level descriptions above each form helper function to clarify its responsibility
- annotate tricky validation and data-normalisation code paths with inline comments for beginners

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d503e04f7883229de57ebfe802f2fd