### PR TITLE
Add explanatory comments to form helpers

### DIFF
--- a/Recipe/src/forms/inventoryForm.js
+++ b/Recipe/src/forms/inventoryForm.js
@@ -1,3 +1,4 @@
+// Reuse helper functions so every form treats text and dates the same way
 const { sanitiseString } = require('../lib/utils');
 const {
   INVENTORY_ID_REGEX,
@@ -9,6 +10,9 @@ const {
 } = require('../lib/validationConstants');
 const { toIsoDate } = require('../lib/date');
 
+// A template object that represents a completely blank inventory form.
+// We copy this whenever we need to render an empty form so we do not mutate
+// the original object by accident.
 const EMPTY_INVENTORY_FORM_VALUES = {
   inventoryId: '',
   userId: '',
@@ -23,19 +27,32 @@ const EMPTY_INVENTORY_FORM_VALUES = {
   createdDate: ''
 };
 
+// Returns a cloned copy of the blank form so each caller gets an independent
+// object. This prevents one caller from accidentally changing the defaults
+// for everyone else.
 function getEmptyInventoryFormValues() {
   return Object.assign({}, EMPTY_INVENTORY_FORM_VALUES);
 }
 
+// Convert the raw HTTP request body into a normalised inventory object.
+// Every field is trimmed, converted to the right data type and given a
+// sensible default so downstream code can rely on it.
 function parseInventoryForm(body) {
   const item = {};
   item.inventoryId = (body.inventoryId || '').trim();
+
+  // Clean user input to avoid leading/trailing whitespace and enforce the
+  // uppercase convention used throughout the application.
   const userIdInput = sanitiseString(body && body.userId);
   item.userId = userIdInput ? userIdInput.toUpperCase() : '';
+
   item.ingredientName = (body.ingredientName || '').trim();
   item.quantity = Number(body.quantity);
   item.unit = (body.unit || '').trim().toLowerCase();
   item.category = (body.category || '').trim();
+
+  // Dates are stored as actual Date objects so later validation can compare
+  // them using getTime rather than working with strings.
   item.purchaseDate = body.purchaseDate ? new Date(body.purchaseDate) : new Date();
   item.expirationDate = body.expirationDate ? new Date(body.expirationDate) : new Date();
   item.location = (body.location || '').trim();
@@ -44,6 +61,9 @@ function parseInventoryForm(body) {
   return item;
 }
 
+// Validate a parsed inventory item and return a list of friendly error
+// messages. Returning an array makes it easy for callers to display every
+// problem to the user at once.
 function collectInventoryErrors(item) {
   const errors = [];
   if (!item) {
@@ -51,6 +71,10 @@ function collectInventoryErrors(item) {
     return errors;
   }
 
+  // Each validation block follows the same pattern:
+  // 1. Clean up the input.
+  // 2. Check it exists.
+  // 3. Validate the format or value range.
   const inventoryId = sanitiseString(item.inventoryId).toUpperCase();
   if (!inventoryId) {
     errors.push('Inventory ID is required.');
@@ -98,6 +122,8 @@ function collectInventoryErrors(item) {
   } else if (cost < 0.01 || cost > 999.99) {
     errors.push('Cost must be between 0.01 and 999.99.');
   } else {
+    // Ensures we do not accept values like 9.999 which the UI cannot display
+    // correctly when rounded to two decimal places.
     const cents = Math.round(cost * 100);
     if (Math.abs(cost * 100 - cents) > 1e-6) {
       errors.push('Cost must have no more than two decimal places.');
@@ -128,6 +154,9 @@ function collectInventoryErrors(item) {
   return errors;
 }
 
+// Prepare an inventory item for display in a form. This function ensures
+// every field is a string or number that the template can render without
+// additional checks.
 function buildInventoryFormValuesFromItem(item) {
   const values = getEmptyInventoryFormValues();
   if (!item) {
@@ -152,6 +181,8 @@ function buildInventoryFormValuesFromItem(item) {
     values.cost = '';
   }
 
+  // Convert Date objects back into the YYYY-MM-DD format expected by
+  // `<input type="date">` fields in the browser.
   values.purchaseDate = toIsoDate(item.purchaseDate);
   values.expirationDate = toIsoDate(item.expirationDate);
   values.createdDate = toIsoDate(item.createdDate);


### PR DESCRIPTION
## Summary
- add high-level comments to the inventory form helper to describe parsing, validation, and view mapping responsibilities
- expand recipe form helpers with beginner-friendly explanations of how each step transforms incoming data
- document user registration and login helper functions so new developers understand the sanitising and validation flow

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d50b8f0e0c8322901bd2c0c13d4abc