### PR TITLE
Add explanatory comments to route handlers

### DIFF
--- a/Recipe/src/routes/index.js
+++ b/Recipe/src/routes/index.js
@@ -1,9 +1,22 @@
+// This file acts as the "traffic controller" for all of the route modules in
+// the application.  Anything that starts with `/src/routes` comes through this
+// router first, and we forward the request to the feature-specific routers.
 const express = require('express');
+
+// Creating a new router instance keeps our route definitions isolated from the
+// main Express app, which helps with organisation and testing.
 const router = express.Router();
+
+// Import the routers that know how to handle recipe- and inventory-related
+// requests.
 const recipesRouter = require('./recipes');
 const inventoryRouter = require('./inventory');
 
+// Plug the feature routers into this parent router. Express will look inside
+// each router and match incoming requests to the first route that fits.
 router.use(recipesRouter);
 router.use(inventoryRouter);
 
+// Exporting the router lets `src/server/server.js` (and any tests) mount it on
+// the main Express application instance.
 module.exports = router;

--- a/Recipe/src/routes/recipes.js
+++ b/Recipe/src/routes/recipes.js
@@ -1,3 +1,6 @@
+// Routes that deal with recipe creation, listing, and management. The extra
+// comments here are intended to help a newer engineer quickly recall how each
+// helper fits into the bigger Express + permissions flow.
 const express = require('express');
 const router = express.Router();
 const constants = require('../lib/constants');
@@ -6,17 +9,22 @@ const store = require('../store');
 const ValidationError = require('../errors/ValidationError');
 const { userCanAccessRecipes, userCanModifyRecipe, userCanViewRecipe } = require('../lib/permissions');
 
+// Route patterns. Centralising them ensures the APP_ID suffix stays in sync
+// everywhere it is referenced.
 const CREATE_PATH = '/add-recipe-' + APP_ID;
 const LIST_PATH = '/recipes-list-' + APP_ID;
 const GET_ONE_PATH = '/recipes/:recipeId-' + APP_ID;
 const UPDATE_PATH = '/recipes/:recipeId/update-' + APP_ID;
 const DELETE_PATH = '/recipes/:recipeId-' + APP_ID;
 
+// Option lists that double as validation references and UI dropdown values.
 const MEAL_TYPES = ['Breakfast', 'Lunch', 'Dinner', 'Snack'];
 const CUISINE_TYPES = ['Italian', 'Asian', 'Mexican', 'American', 'French', 'Indian', 'Mediterranean', 'Other'];
 const DIFFICULTY_OPTIONS = ['Easy', 'Medium', 'Hard'];
 const UNIT_OPTIONS = ['pieces', 'kg', 'g', 'liters', 'ml', 'cups', 'tbsp', 'tsp', 'dozen'];
 
+// Pull the user identifier from any supported request location (query, body,
+// or header) so that every endpoint can share the same auth logic.
 function getUserIdFromRequest(req) {
   const queryId = req && req.query && req.query.userId;
   const bodyId = req && req.body && req.body.userId;
@@ -25,6 +33,7 @@ function getUserIdFromRequest(req) {
   return candidate ? String(candidate).trim().toUpperCase() : '';
 }
 
+// Validate that the user exists and is currently logged in before proceeding.
 async function resolveApiUser(req) {
   const userId = getUserIdFromRequest(req);
   if (!userId) {
@@ -39,6 +48,8 @@ async function resolveApiUser(req) {
   return { user: user };
 }
 
+// Many data-layer errors come in different shapes. This helper converts them
+// into our custom ValidationError so the error handler can show friendly text.
 function normaliseError(err) {
   if (!err) return err;
 
@@ -74,6 +85,8 @@ function normaliseError(err) {
   return err;
 }
 
+// Pick the canonical casing for dropdown-style strings (e.g. "lunch" →
+// "Lunch") to keep comparisons strict and prevent duplicate values.
 function normaliseOption(value, options) {
   if (!value) return value;
   const trimmed = String(value).trim();
@@ -85,6 +98,8 @@ function normaliseOption(value, options) {
   return trimmed;
 }
 
+// Convert the incoming request body into the shapes our store layer expects –
+// trimming strings, converting numbers, and normalising arrays.
 function coerceRecipePayload(body) {
   const out = Object.assign({}, body);
   if (out.recipeId !== undefined) out.recipeId = String(out.recipeId).trim().toUpperCase();
@@ -128,27 +143,34 @@ function coerceRecipePayload(body) {
 // Create a recipe
 router.post(CREATE_PATH, async function (req, res, next) {
   try {
+    // Step 1: confirm that the request is tied to a logged-in user.
     const resolution = await resolveApiUser(req);
     if (!resolution.user) {
       return res.status(resolution.status || 401).json({ error: resolution.message });
     }
 
     const activeUser = resolution.user;
+    // Only chefs have access to recipe endpoints.
     if (!userCanAccessRecipes(activeUser)) {
       return res.status(403).json({ error: 'Recipes are restricted to chef accounts.' });
     }
 
+    // Normalise request body values before persisting them.
     const payload = coerceRecipePayload(req.body || {});
     if (!payload.createdDate) {
       payload.createdDate = new Date();
     }
     payload.userId = activeUser.userId;
+
+    // Prevent duplicate titles for the same user to reduce confusion.
     if (payload.title) {
       const existingTitle = await store.getRecipeByTitleForUser(activeUser.userId, payload.title);
       if (existingTitle) {
         throw new ValidationError(['You already have a recipe with this title.']);
       }
     }
+
+    // Delegate to the data layer and send a 201 Created response.
     const recipe = await store.createRecipe(payload);
     return res.status(201).json({ recipe });
   } catch (err) {
@@ -165,10 +187,14 @@ router.get(LIST_PATH, async function (req, res, next) {
     }
 
     const activeUser = resolution.user;
+    // Listing is also restricted to chef accounts; front-of-house staff should
+    // not see recipes.
     if (!userCanAccessRecipes(activeUser)) {
       return res.status(403).json({ error: 'Recipes are available to chefs only.' });
     }
 
+    // `scope=mine` lets the UI request only the recipes the current chef owns;
+    // otherwise we include public/shared recipes.
     const scope = typeof req.query.scope === 'string' ? req.query.scope.trim().toLowerCase() : '';
     let recipes = [];
     if (scope === 'mine') {
@@ -200,6 +226,8 @@ router.get(GET_ONE_PATH, async function (req, res, next) {
     if (!recipe) {
       return res.status(404).json({ error: 'Recipe not found' });
     }
+    // Chefs can see their own recipes and any recipe the permissions module
+    // marks as viewable (e.g. shared with them).
     if (!userCanViewRecipe(activeUser, recipe)) {
       return res.status(403).json({ error: 'You do not have permission to view this recipe.' });
     }
@@ -227,6 +255,7 @@ router.post(UPDATE_PATH, async function (req, res, next) {
       return res.status(404).json({ error: 'Recipe not found' });
     }
 
+    // Only the original author is permitted to edit.
     if (!userCanModifyRecipe(activeUser, existing)) {
       return res.status(403).json({ error: 'You can only update recipes that you created.' });
     }
@@ -265,6 +294,7 @@ router.delete(DELETE_PATH, async function (req, res, next) {
       return res.status(403).json({ error: 'You can only delete recipes that you created.' });
     }
 
+    // Return 204 No Content to signal a successful deletion with no body.
     const deleted = await store.deleteRecipe(req.params.recipeId, { userId: activeUser.userId });
     if (!deleted) {
       return res.status(404).json({ error: 'Recipe not found' });


### PR DESCRIPTION
## Summary
- add beginner-friendly documentation comments to the shared routes index
- annotate inventory route helpers and endpoints with intent-focused explanations
- document recipe route authentication and workflow steps for clarity

## Testing
- not run (comments only)


------
https://chatgpt.com/codex/tasks/task_e_68d50bed8104832298ca66b14378c8a7